### PR TITLE
Change exit intent bar message

### DIFF
--- a/src/lib/components/ExitIntentDetector.svelte
+++ b/src/lib/components/ExitIntentDetector.svelte
@@ -40,7 +40,7 @@
 	// Prompts ------------------------------------------------------------------------------------------------------
 	let barPrompts = [
 		"The cure for boredom.",
-		"Playtime’s just getting started.",
+		"You know you want to.",
 		"Why stop the fun now?",
 		"Games don’t play themselves.",
 		"A new adventure awaits.",


### PR DESCRIPTION
You don't even have to include the message I added, just I don't like the 'Playtime’s just getting started' prompt!